### PR TITLE
feat: certbot-nginx with templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # HTTPS CA certificates by mkcert
 mkcert
 
+# Template generated files
+nginx/nginx.conf
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ argon2-cffi = "*"
 django-allauth = "~=0.54.0"
 django-vite = "*"
 wagtail = "~=5.1.1"
+jinja2 = "*"
 
 [dev-packages]
 django-stubs = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a7da7d8743a67796162efda5b5e71762b3f6cfff6e7301cdf732364e1ee0cdb"
+            "sha256": "a0078d70656a779944782c26a4b34760342679143c53a54a79f492865d092e04"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "argon2-cffi": {
             "hashes": [
-                "sha256:8c976986f2c5c0e5000919e6de187906cfd81fb1c72bf9d88c01177e77da7f80",
-                "sha256:d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b"
+                "sha256:879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08",
+                "sha256:c670642b78ba29641818ab2e68bd4e6a78ba53b7eff7b4c3815ae16abf91c7ea"
             ],
             "index": "pypi",
-            "version": "==21.3.0"
+            "version": "==23.1.0"
         },
         "argon2-cffi-bindings": {
             "hashes": [
@@ -358,11 +358,11 @@
         },
         "django-widget-tweaks": {
             "hashes": [
-                "sha256:9bfc5c705684754a83cc81da328b39ad1b80f32bd0f4340e2a810cbab4b0c00e",
-                "sha256:fe6b17d5d595c63331f300917980db2afcf71f240ab9341b954aea8f45d25b9a"
+                "sha256:1c2180681ebb994e922c754804c7ffebbe1245014777ac47897a81f57cc629c7",
+                "sha256:a41b7b2f05bd44d673d11ebd6c09a96f1d013ee98121cb98c384fe84e33b881e"
             ],
             "index": "pypi",
-            "version": "==1.4.12"
+            "version": "==1.5.0"
         },
         "djangorestframework": {
             "hashes": [
@@ -434,6 +434,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==0.5.1"
         },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "index": "pypi",
+            "version": "==3.1.2"
+        },
         "jsonschema": {
             "hashes": [
                 "sha256:043dc26a3845ff09d20e4420d6012a9c91c9aa8999fa184e7efcfeccb41e32cb",
@@ -456,6 +464,62 @@
                 "sha256:78495d1df95b6f7dcc694d1ba8994df709c463a1cbac1bf016e1b9a5ce7280b9"
             ],
             "version": "==2021.3"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
+                "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
+                "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
+                "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
+                "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
+                "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
+                "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
+                "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
+                "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
+                "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
+                "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
+                "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
+                "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
+                "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
+                "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
+                "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
+                "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
+                "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
+                "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
+                "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
+                "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
+                "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
+                "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
+                "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
+                "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
+                "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
+                "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
+                "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
+                "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
+                "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
+                "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
+                "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
+                "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
+                "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
+                "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
+                "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
+                "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
+                "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
+                "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
+                "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
+                "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
+                "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
+                "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
+                "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
+                "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
+                "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
+                "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
+                "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
+                "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
+                "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.3"
         },
         "oauthlib": {
             "hashes": [
@@ -1096,31 +1160,36 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1fe816e26e676c1311b9e04fd576543b873576d39439f7c24c8e5c7728391ecf",
-                "sha256:2c9d570f53908cbea326ad8f96028a673b814d9dca7515bf71d95fa662c3eb6f",
-                "sha256:35b13335c6c46a386577a51f3d38b2b5d14aa619e9633bb756bd77205e4bd09f",
-                "sha256:372fd97293ed0076d52695849f59acbbb8461c4ab447858cdaeaf734a396d823",
-                "sha256:42170e68adb1603ccdc55a30068f72bcfcde2ce650188e4c1b2a93018b826735",
-                "sha256:69b32d0dedd211b80f1b7435644e1ef83033a2af2ac65adcdc87c38db68a86be",
-                "sha256:725b57a19b7408ef66a0fd9db59b5d3e528922250fb56e50bded27fea9ff28f0",
-                "sha256:769ddb6bfe55c2bd9c7d6d7020885a5ea14289619db7ee650e06b1ef0852c6f4",
-                "sha256:79c520aa24f21852206b5ff2cf746dc13020113aa73fa55af504635a96e62718",
-                "sha256:84cf9f7d8a8a22bb6a36444480f4cbf089c917a4179fbf7eea003ea931944a7f",
-                "sha256:9166186c498170e1ff478a7f540846b2169243feb95bc228d39a67a1a450cdc6",
-                "sha256:a2500ad063413bc873ae102cf655bf49889e0763b260a3a7cf544a0cbbf7e70a",
-                "sha256:a551ed0fc02455fe2c1fb0145160df8336b90ab80224739627b15ebe2b45e9dc",
-                "sha256:ad3109bec37cc33654de8db30fe8ff3a1bb57ea65144167d68185e6dced9868d",
-                "sha256:b4ea3a0241cb005b0ccdbd318fb99619b21ae51bcf1660b95fc22e0e7d3ba4a1",
-                "sha256:c36011320e452eb30bec38b9fd3ba20569dc9545d7d4540d967f3ea1fab9c374",
-                "sha256:c8a7444d6fcac7e2585b10abb91ad900a576da7af8f5cffffbff6065d9115813",
-                "sha256:cbf18f8db7e5f060d61c91e334d3b96d6bb624ddc9ee8a1cde407b737acbca2c",
-                "sha256:d145b81a8214687cfc1f85c03663a5bbe736777410e5580e54d526e7e904f564",
-                "sha256:eec5c927aa4b3e8b4781840f1550079969926d0a22ce38075f6cfcf4b13e3eb4",
-                "sha256:f3460f34b3839b9bc84ee3ed65076eb827cd99ed13ed08d723f9083cada4a212",
-                "sha256:f3940cf5845b2512b3ab95463198b0cdf87975dfd17fdcc6ce9709a9abe09e69"
+                "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315",
+                "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0",
+                "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373",
+                "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a",
+                "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161",
+                "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275",
+                "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693",
+                "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb",
+                "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65",
+                "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4",
+                "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb",
+                "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243",
+                "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14",
+                "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4",
+                "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1",
+                "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a",
+                "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160",
+                "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25",
+                "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12",
+                "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d",
+                "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92",
+                "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770",
+                "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2",
+                "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70",
+                "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb",
+                "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5",
+                "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.5.0"
+            "version": "==1.5.1"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1156,10 +1225,10 @@
         },
         "types-pytz": {
             "hashes": [
-                "sha256:4fc2a7fbbc315f0b6630e0b899fd6c743705abe1094d007b0e612d10da15e0f3",
-                "sha256:ecdc70d543aaf3616a7e48631543a884f74205f284cefd6649ddf44c6a820aac"
+                "sha256:1a7b8d4aac70981cfa24478a41eadfcd96a087c986d6f150d77e3ceb3c2bdfab",
+                "sha256:65152e872137926bb67a8fe6cc9cfd794365df86650c5d5fdc7b167b0f38892e"
             ],
-            "version": "==2023.3.0.0"
+            "version": "==2023.3.0.1"
         },
         "types-pyyaml": {
             "hashes": [

--- a/docker/production/docker-compose.yml
+++ b/docker/production/docker-compose.yml
@@ -1,9 +1,13 @@
 volumes:
+  # Database
   postgres_data: {}
   postgres_data_backups: {}
   # Shared volumnes for django_nginx
   django_static_files: {}
   django_media_files: {}
+  # HTTP certs
+  certbot_certs: {}
+  certbot_libs: {}
 
 services:
   django:
@@ -49,13 +53,36 @@ services:
     volumes:
       # Copy nginx configuration to container
       - type: bind
-        source: ./nginx.conf
+        source: ../../nginx/nginx.conf
         target: /etc/nginx/nginx.conf
+
+      - type: volume
+        source: certbot_certs
+        target: /etc/letsencrypt
+        read_only: true
 
       # Use this for local https testing
       - type: bind
         source: ../../mkcert
         target: /app/mkcert
+
     ports:
       - "443:443"
 
+  certbot:
+    image: certbot/certbot
+    tty: true
+    container_name: certbot_prod
+    volumes:
+      - type: volume
+        source: certbot_certs
+        target: /etc/letsencrypt
+      - type: volume
+        source: certbot_libs
+        target: /var/lib/letsencrypt
+    # entrypoint: /bin/sh
+    ports:
+      - "80:80"
+    # Prevent this container from start when doing up -d command
+    profiles:
+      - certbot

--- a/docs/testing_prod_locally_procedure.md
+++ b/docs/testing_prod_locally_procedure.md
@@ -24,6 +24,18 @@ Build the production image for Django
 docker build -f docker/production/Dockerfile --tag django_egresados:latest .
 ```
 
+Render all config files that use jinja2
+
+```bash
+docker run --rm \
+--env-file envs/production/django \
+--mount 'type=bind,source=./nginx,destination=/app/nginx' \
+--mount 'type=bind,source=./shscripts,destination=/app/shscripts,readonly' \
+--interactive --tty \
+django_egresados:latest \
+python shscripts/generate_templates.py
+```
+
 Start all services in detached mode
 
 ```bash
@@ -47,5 +59,6 @@ Upload testing fixtures to database
 ```bash
 docker compose run --rm django python manage.py loaddata fixtures/wagtail_pages.json
 ```
+
 
 ## Debugging the service containers

--- a/nginx/nginx_template.conf
+++ b/nginx/nginx_template.conf
@@ -1,6 +1,5 @@
-events { }
 
-# TODO: server name as env variable so nginx can be used in development and prod
+events { }
 
 http {
     # Avoid error was not loaded because its MIME type, "text/html", is not
@@ -12,22 +11,24 @@ http {
     server {
         listen 80 default_server;
         server_name "";
+        # http to https redirect
+        if ($host = {{ hostname }} ) {
+            return 301 https://$host$request_uri;
+        }
         return 444;
     }
+
     server {
 
         # listen 80;
         # listen [::]:80;
-        server_name 127.0.0.1;
+        server_name {{ hostname }};
         listen 443 ssl;
         listen [::]:443 ssl;
 
         # Fix warning for static files
         add_header 'Content-Security-Policy' 'upgrade-insecure-requests';
 
-        # Important ssl_certificates file names have to match the server name
-        ssl_certificate /app/mkcert/127.0.0.1.crt;
-        ssl_certificate_key /app/mkcert/127.0.0.1.key;
 
         location / {
             proxy_pass http://django:8000;
@@ -48,5 +49,18 @@ http {
             # Replacement  for /media/
             alias /app/media/;
         }
+
+        {% if production %}
+        # production certificate
+        ssl_certificate /etc/letsencrypt/live/{{ hostname }}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{ hostname }}/privkey.pem;
+        {% endif %}
+
+        {% if production_test %}
+        # local prod test cerificates
+        ssl_certificate /app/mkcert/127.0.0.1.crt;
+        ssl_certificate_key /app/mkcert/127.0.0.1.key;
+        {% endif %}
+
     }
 }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 -i https://pypi.org/simple
 anyascii==0.3.2; python_version >= '3.3'
-argon2-cffi==21.3.0
+argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0; python_version >= '3.6'
 asgiref==3.7.2; python_version >= '3.7'
 attrs==23.1.0; python_version >= '3.7'
@@ -20,7 +20,7 @@ django-permissionedforms==0.1; python_version >= '3.7'
 django-taggit==4.0.0; python_version >= '3.6'
 django-treebeard==4.7; python_version >= '3.8'
 django-vite==2.1.3
-django-widget-tweaks==1.4.12
+django-widget-tweaks==1.5.0
 djangorestframework==3.14.0
 draftjs-exporter==2.1.7
 drf-spectacular==0.26.4
@@ -30,9 +30,11 @@ gunicorn==21.2.0
 html5lib==1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 idna==3.4; python_version >= '3.5'
 inflection==0.5.1; python_version >= '3.5'
+jinja2==3.1.2
 jsonschema==4.19.0; python_version >= '3.8'
 jsonschema-specifications==2023.7.1; python_version >= '3.8'
 l18n==2021.3
+markupsafe==2.1.3; python_version >= '3.7'
 oauthlib==3.2.2; python_version >= '3.6'
 openpyxl==3.1.2; python_version >= '3.6'
 packaging==23.1; python_version >= '3.7'

--- a/shscripts/generate_templates.py
+++ b/shscripts/generate_templates.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+from dataclasses import dataclass
+import logging
+
+import environ
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+BASE_DIR = Path(__file__).resolve().parent.parent  # The root of this repo
+
+# Add the root dir so we can resolve imports
+sys.path.append(str(BASE_DIR))
+
+DOCKER_DIR = BASE_DIR / "docker" / "production"
+NGINX_DIR = BASE_DIR / "nginx"
+
+env = environ.Env()
+MODE = env("MODE")
+HOSTNAME = env("HOST_NAME")
+
+logging.basicConfig(
+    stream=sys.stdout,
+    datefmt="%Y-%m-%d %H:%M:%S",
+    format="%(asctime)s | %(levelname)s | %(message)s",
+    level=logging.INFO,
+)
+
+jinja_env = Environment(
+    loader=FileSystemLoader(BASE_DIR),
+    autoescape=select_autoescape(),
+    # Remove whitespace that is left behind by jinja syntax
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+context = {
+    "production": MODE == "production",
+    "production_test": MODE == "production_test",
+    "hostname": HOSTNAME,
+}
+
+
+@dataclass
+class TemplateFile:
+    name: str
+    out_name: str
+    path: Path
+
+    def get_template(self):
+        return jinja_env.get_template(
+            f"{self.path.parts[-1]}/{self.name}"
+        )
+
+    def save(self):
+        template = self.get_template()
+        rendered_template = template.render(**context)
+
+        with open(NGINX_DIR / self.out_name, "w") as f:
+            f.write(rendered_template)
+
+        logging.info(msg=f"Saved template {self.out_name}")
+
+if __name__ == "__main__":
+
+    templates = [
+        TemplateFile(path=NGINX_DIR, name="nginx_template.conf", out_name="nginx.conf"),
+    ]
+
+
+    for template in templates:
+        # Save
+        template.save()


### PR DESCRIPTION
Configurar nginx con certbox.

Se utilizaron plantillas de jinja2 para la configuración nginx, para poder probar localmente el setup de producción, y así tener paridad más cercana y mayor seguridad antes de hacer el despliegue al ambiente de producción.