### PR TITLE
feat theme chooser view

### DIFF
--- a/django_src/apps/register/urls.py
+++ b/django_src/apps/register/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
-from .views import MainView, SelectCarreraView, SelectCarrerSpecialization
+from .views import MainView, SelectCarreraView, SelectCarrerSpecialization, SelecThemeView
 
 app_name="register"
 
 urlpatterns = [
     path("select_carrera/", SelectCarreraView.as_view(), name="select_carrera"),
     path("select_carreer_specialization/<str:name>", SelectCarrerSpecialization.as_view(), name="select_specialization"),
+    path("select_themes/<str:name>", SelecThemeView.as_view(), name="select_themes"),
     path("", MainView.as_view(), name="index"),
 
 ]

--- a/django_src/apps/register/views.py
+++ b/django_src/apps/register/views.py
@@ -1,11 +1,21 @@
-from django.db.models.aggregates import Count
-from django.db.models.expressions import When
+from urllib.parse import urlencode
+from collections import OrderedDict
+
+from django.db.models import Prefetch, Q, Value, Case, When
+from django.db import models
+
+from django.views.generic import ListView
 from django.views.generic.base import TemplateView
-from django.views.generic.detail import DetailView
-from django.http import HttpResponse
-from django.db.models import Prefetch
+from django.views.generic.detail import DetailView, SingleObjectMixin
+
+
+from django_htmx.http import trigger_client_event
+
+from django.http import HttpResponse, QueryDict
 from django.urls import reverse_lazy
+
 from .models import Faculty, Carreer
+
 from render_block import render_block_to_string
 
 # Create your views here.
@@ -104,5 +114,105 @@ class SelectCarrerSpecialization(DetailView):
         carrer_set.prefetch_related("carrerspecialization_set")
         return carrer_set
 
+class SelecThemeView(SingleObjectMixin, ListView):
+
+    template_name = "register/select_theme.html"
+    paginate_by = 4
+
+    slug_field = "name"
+    slug_url_kwarg = "name"
+    # context_object_name="interest_themes"
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object(queryset=Carreer.objects.all())
+
+        # Themes from url
+        self.selected_themes_list = self.request.GET.getlist("theme")
+
+        super_response = super().get(request, *args, **kwargs)
+        if not request.htmx:
+            return super_response
+
+        # 3. Student has selected one or more themes and it's requesting a new page of themes
+
+        # Get context data for render_block_to_string
+        ctx = self.get_context_data()
+        ullist_html = render_block_to_string(self.template_name, "theme_list", ctx)
+
+        # Make a response with the rendered new list of themes
+        htmx_reponse = HttpResponse(ullist_html)
+
+        return htmx_reponse
 
 
+    def get_queryset(self):
+        interest_themes = self.object.interest_themes
+
+        # 1. Student hasn't selected any theme
+        if len(self.selected_themes_list) == 0:
+
+            # Order by is need to yield consistent pagination results
+            return interest_themes.order_by("name")
+
+
+        # 2. Student has selected one or more themes
+
+        selected_themes_query = Q(name__in=self.selected_themes_list)
+
+        selected_themes = interest_themes.filter(selected_themes_query).annotate(
+            # Add metadata column to know that the value is selected
+            selected=Value(True, output_field=models.BooleanField()),
+            # Add metadata column to keep the original order
+            relevancy=Case(
+                # Make the order
+                *[
+                    When(name=theme, then=Value(idx, output_field=models.IntegerField()))
+                    for idx,theme in enumerate(self.selected_themes_list)
+                ],
+            ),
+        )
+
+        rest_of_themes = interest_themes.filter(~selected_themes_query).annotate(
+            # Add metadata column to know that the value is not selected
+            selected=Value(False, output_field=models.BooleanField()),
+            # Add metadata column to keep the original order
+            relevancy=Value(len(self.selected_themes_list) + 1, output_field=models.IntegerField())
+        )
+
+        # Make union of querysets and order the resulting set so that the selected themes
+        # are showed first
+        all_themes = selected_themes.union(rest_of_themes).order_by(
+            "-selected",
+            "relevancy",
+            # Id makes the sort unique, otherwise, repeated elements might appear in the pages.
+            # https://stackoverflow.com/questions/5044464/django-pagination-is-repeating-results
+            "id"
+        )
+
+        return all_themes
+
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["carreer"] = self.object
+        context["urlCarrer"] = self.kwargs[self.slug_url_kwarg]
+        context["url_themes"] = self.selected_themes_list
+
+        # Encode the selected themes as query parameter
+        themes_query_str = QueryDict(mutable=True)
+        themes_query_str.setlist("theme", self.selected_themes_list)
+        context["themes_query_param"] = themes_query_str.urlencode()
+        context["themes_query_param_len"] = len(self.selected_themes_list)
+
+        # Add urls for previous steps
+        context["step_urls"] = {
+            **step_urls,
+            "specialization": reverse_lazy(
+                "register:select_specialization",
+                kwargs={
+                    self.slug_url_kwarg: self.kwargs[self.slug_url_kwarg]
+                }
+            )
+        }
+
+        return context

--- a/shscripts/dev.sh
+++ b/shscripts/dev.sh
@@ -18,6 +18,10 @@ cterm(){
   docker-compose run --rm --no-deps -w /app --entrypoint "bash" django
 }
 
+load_env(){
+  set -a
+  source ${1:-.env}
+}
 
 # Wrapper command
 dockerpy(){

--- a/static/src/js/select_specialization.ts
+++ b/static/src/js/select_specialization.ts
@@ -7,30 +7,68 @@ import { profileStore } from "js/alpine_stores"
 const select_spec = (urlCarrer: string) => ({
     specializations: [],
     search_key: "",
-    specialization_selected: Alpine.$persist("").as("specialization"),
+
+    // The selected from localstorage
     profile: Alpine.$persist("").as("profile"),
+
+    // The selected carrer from localstorage
+    carreer: Alpine.$persist('').as('carreer'),
+
+    // The selected specialization from localstorage
+    specialization_selected: Alpine.$persist("").as("specialization"),
+
+    // The selected themes
+    themes: Alpine.$persist<string[]>([]).as("themes"),
+
+    // The carrer from the url path
+    urlCarreer: urlCarrer,
+
     no_tengo: "No tengo especialización",
+
+    // Some errors that might occur
     errorCarreer: false,
     errorProfile: false,
-    urlCarreer: urlCarrer, // The carrer from the url path
-    carreer: Alpine.$persist('').as('carreer'),
-    // The carrer that is in the url path
+
+    /** builds a query parameter from the selected themes in the next step */
+    buildThemeQuery(themes: string[]){
+        const searchParams = new URLSearchParams("")
+
+        // Only adds the query parameter if previous themes were selected
+        themes.forEach((theme) => {
+            searchParams.append("theme", theme)
+        })
+
+        return `?${searchParams.toString()}`
+    },
+
     init(){
         // Grab specializations names that came from the server
         this.specializations = JSON.parse(document.getElementById('specializations').textContent);
-        // Add and special specializations for people that don't have one
+
+        // Add an special specializations for people that don't have one
         this.specializations.push(
             {name:this.no_tengo}
         )
         this.errorCarreer = this.carreer != urlCarrer
         this.errorProfile = this.profile == "mentor"
     },
+
+    /** crafts the url for the next step: choose themes */
     get next_url(){
         if (this.specialization_selected === this.no_tengo){
-            return "/register/select_temas"
+
+            const themes_url = `/register/select_themes/${this.urlCarreer}`
+
+            // Add the selected themes as query parameters only if we have some
+            if (this.themes.length > 0){
+                return `${themes_url}${this.buildThemeQuery(this.themes)}`
+            }
+
+            return themes_url
         }
         return "/register/complete_profile"
     },
+
     /** getter for filtering specializations names */
     get filteredSpecialization() {
         let filtSpecializationGroup = []
@@ -48,6 +86,7 @@ const select_spec = (urlCarrer: string) => ({
     },
 
 })
+
 const selectSpec: myAlpineComponent = {
     name: "select_spec",
     component: select_spec,

--- a/static/src/js/select_theme.ts
+++ b/static/src/js/select_theme.ts
@@ -1,0 +1,62 @@
+import Alpine from "alpinejs"
+import { myAlpineComponent, startAlpine } from "js/utils/alpine"
+
+// Component definition
+const select_theme = (urlCarrer: string) => ({
+
+    // The selected from localstorage
+    profile: Alpine.$persist("").as("profile"),
+
+    // The selected carrer from localstorage
+    carreer: Alpine.$persist('').as('carreer'),
+
+    // The selected specialization from localstorage
+    specialization_selected: Alpine.$persist("").as("specialization"),
+
+    // The carrer from the url path
+    urlCarreer: urlCarrer,
+
+    // The selected themes that come from the url
+    urlThemes: [],
+
+    // The selected themes
+    themes: Alpine.$persist<string[]>([]).as("themes"),
+
+    init(){
+        this.urlThemes = JSON.parse(document.getElementById('url_themes').textContent)
+    },
+
+    get themes_query_url(){
+
+        // Only make the url
+        if (this.urlThemes.length == 0){
+            return ""
+        }
+
+        const searchParams = new URLSearchParams()
+        this.themes.forEach(
+            (item)=>{
+                searchParams.append("theme", item)
+            }
+        )
+        return searchParams.toString()
+    },
+
+    get next_url(){
+        return "Todo"
+    },
+})
+
+const selectTheme: myAlpineComponent = {
+    name: "select_theme",
+    component: select_theme,
+}
+
+// Register component
+startAlpine({
+    components: [
+        selectTheme
+    ],
+    stores: [
+    ]
+})

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -5,7 +5,7 @@
 
 {# attrs define the html attributes that this component can support, if one is missing just add more #}
 
-<button {% attrs autofocus disabled form formaction formenctype formmethod formnovalidate formtarget popovertarget popovertargetaction name type value class id title style tabindex role lang intert x-data x-show @click x-ref %}>
+<button {% attrs autofocus disabled form formaction formenctype formmethod formnovalidate formtarget popovertarget popovertargetaction name type value class id title style tabindex role lang intert x-data x-show @click x-ref hx-boost hx-get hx-post hx-on hx-push-url hx-select hx-select-oob hx-swap hx-swap-oob hx-target hx-trigger hx-vals %}>
     {# Currently this button component only supports bootstrap icons #}
     <div class="flex gap-2">
         {% if icon_left %}

--- a/templates/register/select_theme.html
+++ b/templates/register/select_theme.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% load django_vite slippers %}
+
+{% block title %}
+Temas de interés
+{% endblock title %}
+
+{% block body %}
+<main x-data="select_theme('{{urlCarrer}}')" class="px-20 flex flex-col justify-center items-center">
+
+    {# Numbered Steps #}
+
+    <div class="flex justify-center my-10">
+        {% stepper left_line="false" number=1 text="Seleccionar perfil" url=step_urls.select_perfil %}
+        {% stepper number=2 text="Selecciona tu carrera" url=step_urls.select_carrera %}
+        {% stepper number=3 text="Selecciona tu especialización" url=step_urls.specialization %}
+        {% stepper right_line="false" number=4 text="Temas de interés" %}
+    </div>
+    <h3 class=" text-xl">Elige uno o más temas de interés</h3>
+
+    <form class=" w-[550px] flex gap-y-2 my-6 flex-col justify-center align-center">
+
+        <ul class="flex gap-2 flex-wrap max-h-[80vh] overflow-y-scroll" x-on:fetchedpage="on_new_page">
+            {% block theme_list %}
+                {% for theme in object_list %}
+                    <li class="rounded-2xl bg-slate-600 py-2 px-4 text-white">
+                        <input type="checkbox" name="theme" id="{{ theme.name }}" x-model="themes" value="{{ theme.name }}"/>
+                        <label for="{{ theme.name }}">{{ theme.name }}</label>
+                    </li>
+                {% endfor %}
+
+                {% if page_obj.has_next %}
+                    <li
+                        id="replaceMe"
+                        hx-get="?{{themes_query_param}}{% if themes_query_param_len > 0 %}&{% endif %}page={{ page_obj.next_page_number }}"
+                        hx-target="#replaceMe" hx-swap="outerHTML">
+                        {% #button icon_right="bi bi-plus" type="button" title="Mostrar más" %}
+                        {% /button %}
+                    </li>
+                {% endif %}
+            {% endblock theme_list %}
+        </ul>
+    </form>
+
+    <a x-bind:href="next_url" class="my-4">
+        {% #button icon_right="bi bi-arrow-right" %}
+            Siguiente
+        {% /button %}
+    </a>
+    {# Django objects that are converted to json #}
+    {{ url_themes|json_script:"url_themes" }}
+    {{ page_serialized|json_script:"page_serialized" }}
+</main>
+{% endblock body %}
+
+{% block extrascripts %}
+    {% vite_asset 'js/select_theme.ts' %}
+{% endblock extrascripts %}

--- a/tests/http.py
+++ b/tests/http.py
@@ -1,0 +1,49 @@
+# Core python libs
+from pathlib import Path
+import unittest
+
+from django.http.request import QueryDict, HttpRequest
+
+from django.urls.base import reverse_lazy
+
+from shscripts.backup import (
+    setup_django,
+)
+
+class TestHTTP(unittest.TestCase):
+
+    def setUp(self):
+        self.BASE_DIR = Path(__file__).resolve().parent.parent  # Parent Directory of this file
+        setup_django(self.BASE_DIR)
+
+    # python -m unittest tests.http.TestHTTP.test_queryDict
+    def test_queryDict(self):
+        """
+        # https://docs.djangoproject.com/en/4.2/ref/request-response/#django.http.QueryDict
+        """
+
+        themes = ["Matematicas", "CSS"]
+
+        query_string = "theme=Matematicas&theme=CSS"
+        query_dict = QueryDict(query_string=query_string)
+
+        self.assertEqual(query_dict.getlist("theme"), themes)
+
+        # Build a query string from a query dict
+        q_fresh = QueryDict(mutable=True)
+
+        q_fresh.setlist("theme", themes)
+
+        self.assertEqual(
+            q_fresh.urlencode(),
+            query_string
+        )
+
+    # python -m unittest tests.http.TestHTTP.testHTTPRequest
+    def testHTTPRequest(self):
+        url = reverse_lazy("register:select_themes", kwargs={"name":"Computación"})
+        request = HttpRequest().path = url
+        request.data
+        print(request.build_absolute_uri())
+
+

--- a/tests/model_query.py
+++ b/tests/model_query.py
@@ -4,6 +4,8 @@ test querys of the django model
 """
 import unittest
 from pathlib import Path
+from django.core.paginator import Paginator
+from django.db.models import Q, Value, Case, When
 
 from shscripts.backup import (
     setup_django,
@@ -65,4 +67,75 @@ class TestQuerys(unittest.TestCase):
                 self.computacion.carrerspecialization_set.all().values("name")
             )
         )
+    # python -m unittest tests.model_query.TestQuerys.test_themes_pagination
+    def test_themes_pagination(self):
+        """
+        Please se the view version of this test in
+
+        django_src.apps.register.tests.InterestThemeViewTest.get_with_themes
+        """
+        interest_themes = self.computacion.interest_themes.all()
+        selected_themes_list=["Programación","Matemáticas","BPM"]
+
+        # Make the order
+        order = [
+            When(name=theme, then=Value(idx))
+            for idx,theme in enumerate(selected_themes_list)
+        ]
+
+        self.assertEqual(len(order), len(selected_themes_list))
+
+        selected_themes = interest_themes.filter(name__in=selected_themes_list).annotate(
+            # Add metadata column to know that the value is selected
+            selected=Value(True),
+            # Add metadata column to keep the original order
+            relevancy=Case(
+                *order,
+            ),
+        )
+
+        # Query set should have the same length
+        self.assertEqual(selected_themes.count(), len(selected_themes_list))
+
+        # Check if selected attribute was set, otherwise throws exception
+        print(selected_themes.first().selected)
+
+        # Query set should have the same items
+        for theme in selected_themes.values("name"):
+            self.assertIn(theme["name"], selected_themes_list)
+
+        rest_of_themes = interest_themes.filter(~Q(name__in=selected_themes_list)).annotate(
+            # Add metadata column to know if 
+            selected=Value(False),
+            relevancy=Value(len(selected_themes_list) + 1)
+        )
+
+        # Check if selected attribute was set, otherwise throws exception
+        print(rest_of_themes.first().selected)
+
+        for theme in rest_of_themes.values("name"):
+            self.assertNotIn(theme["name"], rest_of_themes)
+
+        # Make union of querysets
+        all_themes = selected_themes.union(rest_of_themes).order_by("-selected", "relevancy", "id")
+
+        self.assertGreater(all_themes.count(), rest_of_themes.count())
+
+        print(all_themes)
+
+        # First items should be two select and have the same order
+        self.assertEqual(
+            [theme["name"] for theme in all_themes[:len(selected_themes_list)].values("name")],
+            selected_themes_list
+        )
+
+        paginator = Paginator(object_list=all_themes,per_page=4)
+
+        page1 = paginator.get_page(1)
+        page2 = paginator.get_page(page1.next_page_number())
+
+        breakpoint()
+        # Convert querysets to a list, so that they can be compared on equality
+        self.assertEqual(list(page1.object_list), list(all_themes[:len(selected_themes_list)]))
+        self.assertEqual(list(page2.object_list), list(all_themes[len(selected_themes_list):-1]))
 


### PR DESCRIPTION
Closes #62 

Cases
1. User is visiting `/select_themes` for the first time ( no themes have been set ). For pagination don't the send the selected themes in the query params, because the default order is alphabetical.

2. User has already visited `/select_themes` and previously selected one or more themes. If on a previous step, then send the selected themes in the query params