### PR TITLE
147 - Mejorar tabla de aprobaciones

### DIFF
--- a/django_src/apps/register/forms.py
+++ b/django_src/apps/register/forms.py
@@ -434,7 +434,7 @@ class ApprovalsFilterForm(forms.Form):
 
         approval_errors = []
 
-        if action in [RegisterApprovalEvents.APPROVE, RegisterApprovalEvents.REJECT]:
+        if action in [RegisterApprovalEvents.APPROVE, RegisterApprovalEvents.REJECT, RegisterApprovalEvents.RESET]:
 
             if not approvals:
                 return cleaned_data
@@ -448,7 +448,7 @@ class ApprovalsFilterForm(forms.Form):
                     approval_errors.append(
                         ValidationError(
                             _(
-                                "Acción %(accion)s, es inválida para el estado %(state)s de %(user)s"
+                                "Acción '%(accion)s', es inválida para el estado '%(state)s' de '%(user)s'"
                             ),
                             params={
                                 "accion": RegisterApprovalEvents[action].label,

--- a/django_src/apps/register/models.py
+++ b/django_src/apps/register/models.py
@@ -50,6 +50,7 @@ class RegisterApprovalEvents(models.TextChoices):
 
     REJECT = "REJECT", _("Rechazar")
     APPROVE = "APPROVE", _("Aprobar")
+    RESET = "RESET", _("Poner en espera")
 
 
 class RegisterApprovals(models.Model):
@@ -125,6 +126,10 @@ approval_state_machine = {
     },
     RegisterApprovalStates.REJECTED: {
         RegisterApprovalEvents.APPROVE: RegisterApprovalStates.APPROVED,
+        RegisterApprovalEvents.RESET: RegisterApprovalStates.WAITING,
+    },
+    RegisterApprovalStates.APPROVED: {
+        RegisterApprovalEvents.RESET: RegisterApprovalStates.WAITING,
     },
 }
 

--- a/static/src/js/approve_entity.ts
+++ b/static/src/js/approve_entity.ts
@@ -3,12 +3,8 @@ import 'flowbite'
 import { Modal } from 'flowbite';
 import type { ModalOptions } from 'flowbite';
 import htmx from 'htmx.org'
-import { initHTMXutils } from 'js/utils/htmx'
 
 const form_id = "approvals-form"
-
-// Init events listeners for RPC communication beteween the server and the browser
-initHTMXutils()
 
 document.addEventListener("htmx:afterRequest",(evt)=>{
     if(evt.detail.target.id === form_id){

--- a/templates/register/approvals/index.html
+++ b/templates/register/approvals/index.html
@@ -103,35 +103,18 @@
                                 {{RegisterApprovalEvents.APPROVE.label}}
                             {% /button %}
 
-                            {% #button type="submit" name="action" value=RegisterApprovalEvents.REJECT icon_left="bi bi-x" class="text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 dark:focus:ring-red-800 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center" %}
+                            {% #button type="submit" name="action" value=RegisterApprovalEvents.REJECT icon_left="bi bi-x" variant="red" %}
                                 {{RegisterApprovalEvents.REJECT.label}}
                             {% /button %}
+
+                            {% #button type="submit" name="action" value=RegisterApprovalEvents.RESET icon_left="bi bi-x" %}
+                                {{RegisterApprovalEvents.RESET.label}}
+                            {% /button %}
+
                         </div>
+                        {% include "components/info_text.html" with text='Da clic en el Nombre y Apellido para ver el comprobante del usuario' margin="my-2" %}
+
                     </section>
-
-                    {# success messages #}
-
-                    {% if messages %}
-                        {% for message in messages %}
-                            {% if message.level == DEFAULT_MESSAGE_LEVELS.SUCCESS %}
-                                <div id="toast-success" class="flex items-center w-full max-w-xs p-4 mb-4 text-gray-500 bg-white rounded-lg shadow dark:text-gray-400 dark:bg-gray-800 my-4" role="alert">
-                                    <div class="inline-flex items-center justify-center flex-shrink-0 w-8 h-8 text-green-500 bg-green-100 rounded-lg dark:bg-green-800 dark:text-green-200">
-                                        <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>
-                                        </svg>
-                                        <span class="sr-only">Check icon</span>
-                                    </div>
-                                    <div class="ms-3 text-sm font-normal">{{ message.message }}</div>
-                                    <button type="button" class="ms-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8 dark:text-gray-500 dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700" data-dismiss-target="#toast-success" aria-label="Close">
-                                        <span class="sr-only">Close</span>
-                                        <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
 
                     {# Form nonfield Errors #}
                     {% if filter_form.non_field_errors %}
@@ -209,7 +192,7 @@
                                 {% if filter_form.action.value == "search" %}
                                     <span class="text-base mt-4">No hay registros por aprobar que cumplan con los criterios de búsqueda: </span>
                                     <span class="font-bold">Estatus = </span>
-                                    <span>{{ filter_form.status.value }}</span>
+                                    <span>{{ invalid_status }}</span>
                                     <span> y </span>
                                     <span class="font-bold">Tipo = </span>
                                     <span>


### PR DESCRIPTION
Closes #147 
- Ahora una aprobación se puede resetear, esto permite llevar las aprobaciones al estado inicial, en caso de que se realice una equivocación (botón de acción incorrectamente presionado)
- Refactorizar renderizado antiguo de mensajes con el nuevo renderMessages que pone los mensajes flotantes, esto cuando: se apruebe, rechaze o resetee.
- Cuando no se tengan resultados, que aparezca el nombre verbose del estado, no el utilizado para Base de Datos
- `approve_entity.ts` Eliminar JS innecesario