### PR TITLE
Override Wagtail default branding with Egresados UCV branding

### DIFF
--- a/django_src/apps/register/approvals_view.py
+++ b/django_src/apps/register/approvals_view.py
@@ -20,7 +20,6 @@ from django.conf import settings
 from wagtail.admin.mail import send_mail
 from wagtail.admin.utils import get_admin_base_url
 from render_block import render_block_to_string
-from django_htmx.http import trigger_client_event
 
 from django_src.utils.webui import HXSwap, renderMessagesAsToasts
 
@@ -151,9 +150,9 @@ def filter_users(request):
 
 
 def get_absolute_login_url():
-    wagtail_base_url = get_admin_base_url()
-    login_page_url = reverse("wagtailcore_login")
-    return urljoin(wagtail_base_url, login_page_url)
+    base_url: str = settings.BASE_URL
+    login_page_url = reverse("login")
+    return urljoin(base_url, login_page_url)
 
 
 def get_send_approval_email_context(

--- a/django_src/customwagtail/templates/wagtailadmin/base.html
+++ b/django_src/customwagtail/templates/wagtailadmin/base.html
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% block branding_logo %}
+    <img src="{% static 'logo_egresados_ucv.jpg' %}" alt="Logo egresados" width="150" height="150" />
+{% endblock %}

--- a/django_src/customwagtail/templates/wagtailadmin/login.html
+++ b/django_src/customwagtail/templates/wagtailadmin/login.html
@@ -1,0 +1,8 @@
+{% extends "wagtailadmin/login.html" %}
+{% load static %}
+
+{% block branding_logo %}
+    <div style="display: flex; justify-content: center; margin-top: 2em;">
+        <img src="{% static 'logo_egresados_ucv.jpg' %}" alt="Logo egresados" width="100" height="100" />
+    </div>
+{% endblock %}

--- a/django_src/customwagtail/templates/wagtailadmin/notifications/base.html
+++ b/django_src/customwagtail/templates/wagtailadmin/notifications/base.html
@@ -1,0 +1,18 @@
+{% extends 'wagtailadmin/notifications/base.html' %}
+
+{% load custom_wagtail_tags %}
+
+{% block branding_logo %}
+    <table width="600" border="0" align="center" class="mobile" cellspacing="0" cellpadding="0">
+        <tr>
+            <td>
+
+                <div style="display: flex; column-gap: 10px; justify-content: center; align-items: center; background-color: white">
+                    <img src="{% custom_notification_static 'logo_egresados_ucv.jpg' %}" alt="Logo egresados" width="100" height="100" />
+                    {# <img src="https://egresadosucv.org/wp-content/uploads/2019/08/logo.jpg?1e88c4&1e88c4" width="62" height="62" border="0" style="display: block;"> #}
+                    <p style="font-family:Arial, Helvetica, sans-serif; font-size:16px; color: #000000;">Asociación de Egresados y Amigos de la UCV</p>
+                </div>
+            </td>
+        </tr>
+    </table>
+{% endblock %}

--- a/django_src/customwagtail/templates/wagtailadmin/userbar/base.html 
+++ b/django_src/customwagtail/templates/wagtailadmin/userbar/base.html 
@@ -1,0 +1,6 @@
+{% extends "wagtailadmin/userbar/base.html" %}
+{% load static %}
+
+{% block branding_logo %}
+    <img src="{% static 'logo_egresados_ucv.jpg' %}" alt="Logo egresados" width="180" height="180" />
+{% endblock %}

--- a/django_src/customwagtail/templatetags/custom_wagtail_tags.py
+++ b/django_src/customwagtail/templatetags/custom_wagtail_tags.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django import template
+from django.templatetags.static import static
+from urllib.parse import urljoin
+
+register = template.Library()
+
+@register.simple_tag
+def custom_notification_static(path):
+    """
+    Variant of the {% static %}` tag for use in notification emails - tries to form
+    a full URL using WAGTAILADMIN_BASE_URL if the static URL isn't already a full URL.
+    """
+    base_url: str = settings.BASE_URL
+    return urljoin(base_url, static(path))

--- a/django_src/settings/development.py
+++ b/django_src/settings/development.py
@@ -50,6 +50,9 @@ PRIVATE_MEDIA_ROOT = os.path.join(BASE_DIR, "private_media")
 # Gunicorn worker will have cached templates, so disable them in development
 TEMPLATES[0]["OPTIONS"]["loaders"] = default_loaders
 
+# BASE_URL is used links in email content when sending emails
+BASE_URL = f"https://{env('HOST_NAME')}:8000"
+
 # WAGTAILADMIN_BASE_URL required for notification emails
 WAGTAILADMIN_BASE_URL = f"https://{env('HOST_NAME')}:8000"
 WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = "noreply@egresados.org"

--- a/django_src/settings/production.py
+++ b/django_src/settings/production.py
@@ -48,6 +48,7 @@ SECURE_SSL_REDIRECT = True
 # X_FRAME_OPTIONS = "SAMEORIGIN"
 
 # TODO: test
+BASE_URL = f"https://{os.getenv('HOST_NAME')}"
 WAGTAILADMIN_BASE_URL = f"https://{os.getenv('HOST_NAME')}"
 WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = os.getenv("WAGTAILADMIN_NOTIFICATION_FROM_EMAIL")
 # The support email for requests / questions


### PR DESCRIPTION
Closes #149 

- En el CMS, en la barra izquierda de navegación, el logo de Wagtail es reemplazado por el de la Asociación de Egresados de la UCV.

- El Logo de Wagtail en los emails de notificaciones enviados por el CMS, es reemplazado por el de la Asociación de Egresados de la UCV.

- Fixes:
  - Se puso el link correcto de login en emails de aprobación, la razón del error: la URL no es absoluta, era relativa.

Se consultó la documentación de [custom branding](https://docs.wagtail.org/en/stable/advanced_topics/customisation/admin_templates.html#id1) para realizar estos cambios.

Merci!